### PR TITLE
Update outdated description in JavaDoc

### DIFF
--- a/bukkit/src/main/javadoc/overview.html
+++ b/bukkit/src/main/javadoc/overview.html
@@ -1,5 +1,5 @@
 <body>
-    <p>MobChip, a NMS Pathfinder and Entity AI Wrapper made for MC 1.13+, containing implementation from the Bukkit API.</p>
+    <p>MobChipLite, a NMS Pathfinder and Entity AI Wrapper made for MC 1.17+, containing implementation from the Bukkit API.</p>
 
 
 </body>


### PR DESCRIPTION
## Details
The JavaDoc overview contained some outdated information, relevant before forking from MobChip to MobChipLite.
